### PR TITLE
Initial commit of packml_msgs ROS package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(packml_msgs)
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+
+add_message_files(
+  DIRECTORY msg
+  FILES
+    Mode.msg
+    State.msg
+    Stats.msg
+    Status.msg
+    ItemizedStats.msg
+)
+
+add_service_files(
+  DIRECTORY srv
+  FILES
+    ModeChange.srv
+    Transition.srv
+    ResetStats.srv
+)
+
+
+generate_messages(
+  DEPENDENCIES
+    std_msgs
+)
+
+
+catkin_package(
+  CATKIN_DEPENDS message_runtime std_msgs
+)
+
+
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # packml_msgs
+
+ROS API for the PackML state machine. For more information: 
+ - PackML standard: https://en.wikipedia.org/wiki/PackML
+ - PackML ROS implementation: https://github.com/ros-industrial-consortium/packml

--- a/msg/ItemizedStats.msg
+++ b/msg/ItemizedStats.msg
@@ -1,0 +1,7 @@
+# This message contains itemized statiistics for PackML statistics reporting
+# Each item containds a unique ID that defines the "item".  
+# Example usage includes, error and warning events.
+
+int16 id                          # unique identifier (user defined)
+int32 count                       # number of occurances
+std_msgs/Duration duration        # duration in "item" state

--- a/msg/Mode.msg
+++ b/msg/Mode.msg
@@ -1,0 +1,14 @@
+# PackML Mode, based on the PackML standard, summarized here:
+# http://www.plcopen.org/pages/promotion/publications/downloads/mapping_omac_statediagram.pdf
+
+# Enumeration values are based upon tag guidelines, here:
+# http://sesam-world.com/_pdf/make2pack/mode/2010-11-29/Materiale/PackML_Tag_Naming_Guidelines_V2.0.pdf
+
+int8 UNDEFINED = 0
+int8 AUTOMATIC = 1
+int8 SEMI_AUTOMATIC = 2
+int8 MANUAL = 3
+int8 IDLE = 4
+int8 SETUP = 11  # not defined in tag standard, but mentioned in state standard
+
+int8 val

--- a/msg/State.msg
+++ b/msg/State.msg
@@ -1,0 +1,32 @@
+# PackML State, based on the PackML standard, summarized here:
+# http://www.plcopen.org/pages/promotion/publications/downloads/mapping_omac_statediagram.pdf
+
+# Enumeration values are based upon tag guidelines, here:
+# http://sesam-world.com/_pdf/make2pack/mode/2010-11-29/Materiale/PackML_Tag_Naming_Guidelines_V2.0.pdf
+# Due to changes in the standard some states weren't enumerated.  I've made my best guess
+# below
+
+# Values defined in tag naming guidelines
+int8 UNDEFINED = 0
+int8 OFF = 1            # Deleted in V3.0 of packml
+int8 STOPPED = 2
+int8 STARTING = 3
+int8 IDLE = 4
+int8 SUSPENDED = 5
+int8 EXECUTE = 6
+int8 STOPPING = 7
+int8 ABORTING = 8
+int8 ABORTED = 9
+int8 HOLDING = 10
+int8 HELD = 11
+
+# Values NOT defined in tag naming guidelines
+int8 RESETTING = 100
+int8 SUSPENDING = 101    # Not enumerated in tag guidelines
+int8 UNSUSPENDING = 102
+int8 CLEARING = 103
+int8 UNHOLDING = 104
+int8 COMPLETING = 105
+int8 COMPLETE = 106
+
+int8 val

--- a/msg/Stats.msg
+++ b/msg/Stats.msg
@@ -1,0 +1,29 @@
+# This message contains machine agnostic information that is extracted from PackML
+# standard states
+
+std_msgs/Header header       # Time stamp when stats were captured
+std_msgs/Duration duration      # Duration over which statistics are calculated
+
+# State duration - Sum of state durations should equal total duraction above
+std_msgs/Duration idle_duration
+std_msgs/Duration exe_duration
+std_msgs/Duration held_duration
+std_msgs/Duration susp_duration
+std_msgs/Duration cmplt_duration
+std_msgs/Duration stop_duration
+std_msgs/Duration abort_duration
+
+ItemizedStats[] error_items          # Each item represents a machine fault
+ItemizedStats[] quality_items        # Each item represents a quality state
+
+int32 cycle_count               # General cycle count
+int32 success_count             # Number of successful cycles
+int32 fail_count                # Number of failure cycles
+float32 throughput              # Successful cycles/exe_duration above
+
+# Derives/calculated statistics
+# OEE - https://en.wikipedia.org/wiki/Overall_equipment_effectiveness
+float32 availability
+float32 performance
+float32 quality
+float32 overall_equipment_effectiveness

--- a/msg/Status.msg
+++ b/msg/Status.msg
@@ -1,0 +1,14 @@
+# This PackML status message captures the PackML state machine data.  It's
+# meant to be published continuously or latched/on changes (depending on
+# implementation)
+# Based on PackML summarized here:
+# http://www.plcopen.org/pages/promotion/publications/downloads/mapping_omac_statediagram.pdf
+
+
+std_msgs/Header header  # data time stamp
+State state             # standard PackML state
+int16 sub_state         # non-standard state within standard PackML state (0 if no sub-state)
+Mode mode               # standard PackML mode
+int16 error             # TODO: define standard errors (probably in a seperate msg)
+int16 sub_error         # non-standard/user defined error code
+

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>packml_msgs</name>
+  <version>0.0.0</version>
+  <description>Packml messages</description>
+  <maintainer email="shaun.edwards@gmail.com">Shaun Edwards</maintainer>
+  <license>Apache 2.0</license>
+  <author>Shaun Edwards</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <depend>std_msgs</depend>
+  <exec_depend>message_runtime</exec_depend>
+
+</package>

--- a/srv/ModeChange.srv
+++ b/srv/ModeChange.srv
@@ -1,0 +1,13 @@
+# Request a mode change from a packml state machine.
+# The response is returned as soon as the request is accepted, but not necessarily
+# when the mode changes
+
+Mode mode
+
+---
+# State machine response
+bool success         # True if mode has been accepted
+int8 error_code       # Error code if command has been rejected
+int8 SUCCESS = 1
+int8 INVALID_MODE_REQUEST = -1
+string message        # Message for display (only for human reading)

--- a/srv/ResetStats.srv
+++ b/srv/ResetStats.srv
@@ -1,0 +1,11 @@
+# Request a reset of statistics published on stats topic.  This service
+# should be called occasionally to prevent variable overflow (although the
+# variables are suitably large).
+# This service can also be used to track statistics on a remote system.  The
+# "last stats" represent the stats before the reset call.  These stats can be
+# "added" to previous calls as required
+
+---
+# State machine response
+bool success         # True if reset was successful
+Stats last_stat      # Last statistic before reset applied.

--- a/srv/Transition.srv
+++ b/srv/Transition.srv
@@ -1,0 +1,37 @@
+# Request a state change from a packml state machine.  The command set is based
+# on the PackML summarized here:
+# http://www.plcopen.org/pages/promotion/publications/downloads/mapping_omac_statediagram.pdf
+# The response is returned as soon as the request is accepted, but not necessarily
+# when the state changes
+#
+# Enumeration values are based upon tag guidelines, here:
+# http://sesam-world.com/_pdf/make2pack/mode/2010-11-29/Materiale/PackML_Tag_Naming_Guidelines_V2.0.pdf
+
+
+# Values defined in tag naming guidelines
+int8 UNDEFINED = 0
+int8 CLEAR = 1        # Assumed to be "Prepare" in tag naming guidelines
+int8 START = 2
+int8 STOP = 3
+int8 HOLD = 4
+int8 ABORT = 5
+int8 RESET = 6        # Assumed to be "Home"
+int8 ESTOP = 7        # Not clear what state this drives or how it's different from an abort
+
+
+# Values NOT defined in tag naming guidelines
+int8 SUSPEND = 100
+int8 UNSUSPEND = 101
+int8 UNHOLD = 102
+
+int8 command
+---
+# State machine response
+bool success         # True if command has been accepted
+
+int8 SUCCESS = 1
+int8 INVALID_TRANSITION_REQUEST = -1
+int8 UNRECGONIZED_REQUEST = -2
+int8 error_code       # Error code if command has been rejected
+
+string message        # Message for display (only for human reading)


### PR DESCRIPTION
Isolate the ROS API from the ROS implementation.  The packml_msgs were originally here:
https://github.com/ros-industrial-consortium/packml/tree/indigo-devel/packml_msgs

It should be noted that the implementation should depend on the or else the 2 variants of packml_msgs will fall out of sync.  There are also no releases for either packml_msgs package, which can cause dependency problems. 

Closes #1.